### PR TITLE
Sentry was updated

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/sentry-kotlin-multiplatform/build.gradle.kts
+++ b/sentry-kotlin-multiplatform/build.gradle.kts
@@ -8,10 +8,10 @@ plugins {
 }
 
 android {
-    compileSdk = 30
+    compileSdk = 31
     defaultConfig {
         minSdk = 16
-        targetSdk = 30
+        targetSdk = 31
     }
 
     buildTypes {

--- a/sentry-kotlin-multiplatform/build.gradle.kts
+++ b/sentry-kotlin-multiplatform/build.gradle.kts
@@ -46,7 +46,7 @@ kotlin {
 
         val androidMain by getting {
             dependencies {
-                implementation("io.sentry:sentry-android:6.3.1") {
+                implementation("io.sentry:sentry-android:6.17.0") {
                     // avoid duplicate dependencies since we depend on commonJvmMain
                     exclude("io.sentry", "sentry")
                 }
@@ -61,7 +61,7 @@ kotlin {
             jvmMain.dependsOn(this)
             androidMain.dependsOn(this)
             dependencies {
-                implementation("io.sentry:sentry:6.3.1")
+                implementation("io.sentry:sentry:6.17.0")
             }
         }
         val commonJvmTest by creating {
@@ -100,9 +100,9 @@ kotlin {
             summary = "Official Sentry SDK Kotlin Multiplatform"
             homepage = "https://github.com/getsentry/sentry-kotlin-multiplatform"
 
-            pod("Sentry", "~> 7.24.1")
+            pod("Sentry", "~> 8.3.3")
 
-            ios.deploymentTarget = "9.0"
+            ios.deploymentTarget = "16.2"
         }
     }
 

--- a/sentry-kotlin-multiplatform/sentry_kotlin_multiplatform.podspec
+++ b/sentry-kotlin-multiplatform/sentry_kotlin_multiplatform.podspec
@@ -11,9 +11,9 @@ Pod::Spec.new do |spec|
     spec.libraries                = "c++"
     spec.module_name              = "#{spec.name}_umbrella"
 
-    spec.ios.deployment_target = '9.0'
+    spec.ios.deployment_target = '16.2'
 
-    spec.dependency 'Sentry', '~> 7.24.1'
+    spec.dependency 'Sentry', '~> 8.3.3'
 
     spec.pod_target_xcconfig = {
         'KOTLIN_PROJECT_PATH' => ':sentry-kotlin-multiplatform',

--- a/sentry-kotlin-multiplatform/src/commonAppleMain/kotlin/io/sentry/kotlin/multiplatform/extensions/SentryOptionsExtensions.kt
+++ b/sentry-kotlin-multiplatform/src/commonAppleMain/kotlin/io/sentry/kotlin/multiplatform/extensions/SentryOptionsExtensions.kt
@@ -20,7 +20,7 @@ internal fun CocoaSentryOptions.applyCocoaBaseOptions(options: SentryOptions) {
     this.dsn = options.dsn
     this.attachStacktrace = options.attachStackTrace
     this.dist = options.dist
-    this.environment = options.environment
+    this.environment = options.environment.orEmpty()
     this.releaseName = options.release
     this.debug = options.debug
     this.sessionTrackingIntervalMillis = options.sessionTrackingIntervalMillis.convert()

--- a/sentry-samples/kmp-app/shared/build.gradle.kts
+++ b/sentry-samples/kmp-app/shared/build.gradle.kts
@@ -16,10 +16,10 @@ kotlin {
     cocoapods {
         summary = "Some description for the Shared Module"
         homepage = "Link to the Shared Module homepage"
-        ios.deploymentTarget = "14.1"
+        ios.deploymentTarget = "16.2"
         podfile = project.file("../iosApp/Podfile")
 
-        pod("Sentry", "~> 7.21.0")
+        pod("Sentry", "~> 8.3.3")
 
         framework {
             baseName = "shared"

--- a/sentry-samples/kmp-app/shared/shared.podspec
+++ b/sentry-samples/kmp-app/shared/shared.podspec
@@ -11,9 +11,9 @@ Pod::Spec.new do |spec|
     spec.libraries                = "c++"
     spec.module_name              = "#{spec.name}_umbrella"
 
-    spec.ios.deployment_target = '14.1'
+    spec.ios.deployment_target = '16.2'
 
-    spec.dependency 'Sentry', '~> 7.21.0'
+    spec.dependency 'Sentry', '~> 8.3.3'
 
     spec.pod_target_xcconfig = {
         'KOTLIN_PROJECT_PATH' => ':sentry-samples:kmp-app:shared',


### PR DESCRIPTION
- Android target and compile versions were updated from 30 to 31.
- Gradle was updated from 7.4.2 to 7.5.1 to fix issue:
```
> Task :sentry-kotlin-multiplatform:generateDebugRFile FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':sentry-kotlin-multiplatform:generateDebugRFile'.
> Multiple build operations failed.
java.nio.file.NoSuchFileException: /Users/leokapanen/.gradle/caches/transforms-3/18c9754c5414418e9f155d9c14549b76/results.bin
java.nio.file.NoSuchFileException: /Users/leokapanen/.gradle/caches/transforms-3/554166ad08a7b2e04ac0db776a5a23c1/results.bin
java.nio.file.NoSuchFileException: /Users/leokapanen/.gradle/caches/transforms-3/4e97ff2e1aa4ecf0e3b2f5d019d1a52a/results.bin
> java.nio.file.NoSuchFileException: /Users/leokapanen/.gradle/caches/transforms-3/18c9754c5414418e9f155d9c14549b76/results.bin
> java.nio.file.NoSuchFileException: /Users/leokapanen/.gradle/caches/transforms-3/554166ad08a7b2e04ac0db776a5a23c1/results.bin
> java.nio.file.NoSuchFileException: /Users/leokapanen/.gradle/caches/transforms-3/4e97ff2e1aa4ecf0e3b2f5d019d1a52a/results.bin
```

- Sentry was updated to version `6.17.0` for Android and Java, `8.3.3` for iOS.
`ios.deploymentTarget` was set to `16.2`. 
 We need updated version of Sentry for iOS to fix issue:
 ```
 ▸ Running script 'Run Script'
⚠️  ld: directory not found for option '-F/Users/vagrant/git/SplendoHealth/shared/src/nativeInterop/cinterop/Carthage/Build/Sentry.xcframework/[REDACTED]-arm64_i386_x86_64-simulator'
❌  ld: framework not found Sentry
```